### PR TITLE
ci(coveralls): move coveralls upload to GitHub Action with fail-on-error: false

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -49,9 +49,16 @@ jobs:
           CI_PULL_REQUEST: ${{ env.PULL_REQUEST_EVENT }}
           COMPOSE_INTERACTIVE_NO_CLI: 1
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           DBDOCS_TOKEN: ${{ secrets.DBDOCS_TOKEN }}
           WEBDOMAIN: ${{ secrets.WEBDOMAIN }}
           NEXT_AUTH_SECRET_KEY: ${{ secrets.NEXT_AUTH_SECRET_KEY }}
         run: |
           ./ci/test.sh
+
+      - name: Upload coverage to Coveralls
+        if: steps.test_script.outcome == 'success'
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./backend/coverage.lcov
+          fail-on-error: false

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -16,13 +16,7 @@ COVERAGE_PROCESS_START=./.coveragerc \
 echo "Coverage"
 coverage combine --rcfile=./.coveragerc
 coverage report -m --rcfile=./.coveragerc
-
-if [[ -n "${COVERALLS_REPO_TOKEN:-}" ]] ; then
-  export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
-  git config --global --add safe.directory /app
-  # echo "Uploading coverage to coveralls"
-  # coveralls
-fi
+coverage lcov --rcfile=./.coveragerc -o coverage.lcov
 
 echo "Generate Django DBML"
 ./manage.py dbml > db.dbml

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,7 +27,6 @@ services:
       - DB_HOST=db
       - DEBUG=True
       - SECRET_KEY=secret
-      - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN:-}
       - MAILJET_APIKEY=secret
       - MAILJET_SECRET=secret
       - WEBDOMAIN=notset


### PR DESCRIPTION
move coveralls upload to GitHub Action with fail-on-error: false

Coveralls service has been experiencing 500 errors, causing CI failures. Move the upload out of backend/test.sh into a dedicated workflow step using coverallsapp/github-action@v2 so failures don't block the pipeline.